### PR TITLE
Removal of obsolete ng-click

### DIFF
--- a/src/templates/calendarMonthView.html
+++ b/src/templates/calendarMonthView.html
@@ -12,8 +12,7 @@
         ng-init="dayIndex = vm.view.indexOf(day)"
         class="cal-cell1 cal-cell {{ day.highlightClass }}"
         ng-style="{backgroundColor: day.backgroundColor}"
-        ng-class="{pointer: day.events.length > 0}"
-        role="none" tabindex="-1">
+        ng-class="{pointer: day.events.length > 0}">
         <ng-include src="vm.customTemplateUrls.calendarMonthCell || vm.calendarConfig.templates.calendarMonthCell"></ng-include>
       </div>
     </div>

--- a/src/templates/calendarMonthView.html
+++ b/src/templates/calendarMonthView.html
@@ -12,6 +12,7 @@
         ng-init="dayIndex = vm.view.indexOf(day)"
         class="cal-cell1 cal-cell {{ day.highlightClass }}"
         ng-style="{backgroundColor: day.backgroundColor}"
+        ng-click="vm.dayClicked(day, false, $event)"
         ng-class="{pointer: day.events.length > 0}"
         role="none" tabindex="-1">
         <ng-include src="vm.customTemplateUrls.calendarMonthCell || vm.calendarConfig.templates.calendarMonthCell"></ng-include>

--- a/src/templates/calendarMonthView.html
+++ b/src/templates/calendarMonthView.html
@@ -12,7 +12,8 @@
         ng-init="dayIndex = vm.view.indexOf(day)"
         class="cal-cell1 cal-cell {{ day.highlightClass }}"
         ng-style="{backgroundColor: day.backgroundColor}"
-        ng-class="{pointer: day.events.length > 0}">
+        ng-class="{pointer: day.events.length > 0}"
+        role="none" tabindex="-1">
         <ng-include src="vm.customTemplateUrls.calendarMonthCell || vm.calendarConfig.templates.calendarMonthCell"></ng-include>
       </div>
     </div>

--- a/src/templates/calendarMonthView.html
+++ b/src/templates/calendarMonthView.html
@@ -12,7 +12,6 @@
         ng-init="dayIndex = vm.view.indexOf(day)"
         class="cal-cell1 cal-cell {{ day.highlightClass }}"
         ng-style="{backgroundColor: day.backgroundColor}"
-        ng-click="vm.dayClicked(day, false, $event)"
         ng-class="{pointer: day.events.length > 0}"
         role="none" tabindex="-1">
         <ng-include src="vm.customTemplateUrls.calendarMonthCell || vm.calendarConfig.templates.calendarMonthCell"></ng-include>

--- a/src/templates/calendarMonthView.html
+++ b/src/templates/calendarMonthView.html
@@ -13,7 +13,8 @@
         class="cal-cell1 cal-cell {{ day.highlightClass }}"
         ng-style="{backgroundColor: day.backgroundColor}"
         ng-click="vm.dayClicked(day, false, $event)"
-        ng-class="{pointer: day.events.length > 0}">
+        ng-class="{pointer: day.events.length > 0}"
+        role="none" tabindex="-1">
         <ng-include src="vm.customTemplateUrls.calendarMonthCell || vm.calendarConfig.templates.calendarMonthCell"></ng-include>
       </div>
     </div>


### PR DESCRIPTION
These changes cater for tickets SS-9109 and SS-9110. 
These tickets are 508 issues which are having a negative effect on screen readers as well as the normal tabbing.
A user has to tab twice to get to the next day and the key event, of hitting enter, only fires when having  tabbed twice on a day.

The ng-click event (which also caters for the Enter key event) is handled within a custom script in the seachCalendarView.html file.

By removing the ng-click, the role and tabindex attributes are not generated on this repeated div element. Tabbing works correctly with one tab press and the screen reader no longer reads the date two times.
